### PR TITLE
use docker compose v2 no init-letsengrypt

### DIFF
--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if ! [ -x "$(command -v docker-compose)" ]; then
-  echo 'Error: docker-compose is not installed.' >&2
+if ! docker compose version >/dev/null 2>&1; then
+  echo 'Error: docker compose is not installed.' >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Resumo

Atualiza a checagem inicial de `init-letsencrypt.sh` para usar `docker compose` em vez de `docker-compose`, compatibilizando o script com Docker Compose v2.
